### PR TITLE
Rebased Pull request #10 : Fixed wrong return value for `CREATE`, `ALTER`, `TRUNCATE` and `DROP`

### DIFF
--- a/db.php
+++ b/db.php
@@ -1278,7 +1278,9 @@ class LudicrousDB extends wpdb {
 			return false;
 		}
 
-		if ( preg_match( "/^\\s*(insert|delete|update|replace|alter) /i", $query ) ) {
+		if ( preg_match( '/^\s*(create|alter|truncate|drop)\s/i', $query ) ) {
+			$return_val = $this->result;
+		} elseif ( preg_match( "/^\\s*(insert|delete|update|replace|alter) /i", $query ) ) {
 			if ( true === $this->use_mysqli ) {
 				$this->rows_affected = mysqli_affected_rows( $this->dbh );
 			} else {

--- a/readme.txt
+++ b/readme.txt
@@ -76,6 +76,9 @@ Since LudicrousDB attempts a connection only when a query is made, your WordPres
 
 == Changelog ==
 
+= Next =
+* Fixed wrong return value for `CREATE`, `ALTER`, `TRUNCATE` and `DROP` queries
+
 = 2.0 =
 * Fork from HyperDB
 * Include utf8mb4 support (for WordPress 4.2 compatibility)


### PR DESCRIPTION
This is the same pull request as #10 but just the last commit. Somehow the 2 repositories have diverged with different SHA for the corresponding commits between them. 

- Added a condition to return bool(true) instead of int(0) for those
  queries
- Updated `readme.txt`

This is now complying with the Codex specification in
https://codex.wordpress.org/Class_Reference/wpdb#General_Syntax

This fix is required for
https://wordpress.org/support/topic/truncate-queries-return-wrong-data-type