### PR TITLE
Use constants for pathes

### DIFF
--- a/ludicrousdb/drop-ins/db.php
+++ b/ludicrousdb/drop-ins/db.php
@@ -15,9 +15,12 @@
 // Exit if accessed directly
 defined( 'ABSPATH' ) || exit;
 
+$wp_plugin_dir = ( defined('WP_PLUGIN_DIR') ) ? WP_PLUGIN_DIR : WP_CONTENT_DIR . '/plugins';
+$wpmu_plugin_dir = ( defined('WP_PLUGIN_DIR') ) ? WPMU_PLUGIN_DIR : WP_CONTENT_DIR . '/mu-plugins';
+
 // Require the main plugin file
-if ( file_exists( WP_PLUGIN_DIR . '/ludicrousdb/ludicrousdb.php' ) ) {
-	require_once WP_PLUGIN_DIR . '/ludicrousdb/ludicrousdb.php';
-} elseif ( file_exists( WPMU_PLUGIN_DIR . '/ludicrousdb/ludicrousdb.php' ) ) {
-	require_once WPMU_PLUGIN_DIR . '/ludicrousdb/ludicrousdb.php';
+if ( file_exists(  $wp_plugin_dir . '/ludicrousdb/ludicrousdb.php' ) ) {
+	require_once $wp_plugin_dir . '/ludicrousdb/ludicrousdb.php';
+} elseif ( file_exists( $wpmu_plugin_dir . '/ludicrousdb/ludicrousdb.php' ) ) {
+	require_once $wpmu_plugin_dir . '/ludicrousdb/ludicrousdb.php';
 }

--- a/ludicrousdb/drop-ins/db.php
+++ b/ludicrousdb/drop-ins/db.php
@@ -16,7 +16,7 @@
 defined( 'ABSPATH' ) || exit;
 
 $wp_plugin_dir = ( defined('WP_PLUGIN_DIR') ) ? WP_PLUGIN_DIR : WP_CONTENT_DIR . '/plugins';
-$wpmu_plugin_dir = ( defined('WP_PLUGIN_DIR') ) ? WPMU_PLUGIN_DIR : WP_CONTENT_DIR . '/mu-plugins';
+$wpmu_plugin_dir = ( defined('WPMU_PLUGIN_DIR') ) ? WPMU_PLUGIN_DIR : WP_CONTENT_DIR . '/mu-plugins';
 
 // Require the main plugin file
 if ( file_exists(  $wp_plugin_dir . '/ludicrousdb/ludicrousdb.php' ) ) {

--- a/ludicrousdb/drop-ins/db.php
+++ b/ludicrousdb/drop-ins/db.php
@@ -16,8 +16,8 @@
 defined( 'ABSPATH' ) || exit;
 
 // Require the main plugin file
-if ( file_exists( WP_CONTENT_DIR . '/plugins/ludicrousdb/ludicrousdb.php' ) ) {
-	require_once WP_CONTENT_DIR . '/plugins/ludicrousdb/ludicrousdb.php';
-} elseif ( file_exists( WP_CONTENT_DIR . '/mu-plugins/ludicrousdb/ludicrousdb.php' ) ) {
-	require_once WP_CONTENT_DIR . '/mu-plugins/ludicrousdb/ludicrousdb.php';
+if ( file_exists( WP_PLUGIN_DIR . '/ludicrousdb/ludicrousdb.php' ) ) {
+	require_once WP_PLUGIN_DIR . '/ludicrousdb/ludicrousdb.php';
+} elseif ( file_exists( WPMU_PLUGIN_DIR . '/ludicrousdb/ludicrousdb.php' ) ) {
+	require_once WPMU_PLUGIN_DIR . '/ludicrousdb/ludicrousdb.php';
 }


### PR DESCRIPTION
Core has WP_PLUGIN_DIR and WPMU_PLUGIN_DIR constants, so you can change the path of where mu / plugins are stored. We should use them. 