### PR TITLE
Updated the Plugin URL

### DIFF
--- a/ludicrousdb.php
+++ b/ludicrousdb.php
@@ -2,7 +2,7 @@
 
 /**
  * Plugin Name: LudicrousDB
- * Plugin URI:  https://wordpress.org/plugins/ludicrousdb/
+ * Plugin URI:  https://github.com/stuttter/ludicrousdb
  * Author:      John James Jacoby
  * Author URI:  https://jjj.blog
  * License:     GPL v2 or later


### PR DESCRIPTION
The URL used for the 'Visit plugin site' link on the plugins list at wp-admin is broken. https://wordpress.org/plugins/ludicrousdb/ does not exist.