### PR TITLE
only ping once per page load per dbh thread

### DIFF
--- a/ludicrousdb/drop-ins/db-config.php
+++ b/ludicrousdb/drop-ins/db-config.php
@@ -40,14 +40,6 @@ $wpdb->collate = 'utf8mb4_unicode_ci';
 $wpdb->save_queries = false;
 
 /**
- * recheck_timeout (float)
- * The amount of time to wait before trying again to ping mysql server.
- *
- * Default: 0.1 (Seconds)
- */
-$wpdb->recheck_timeout = 0.1;
-
-/**
  * persistent (bool)
  * This determines whether to use mysql_connect or mysql_pconnect. The effects
  * of this setting may vary and should be carefully tested.

--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -1150,12 +1150,12 @@ class LudicrousDB extends wpdb {
 			if ( $this->dbh_type_check( $dbh ) ) {
 				if ( true === $this->use_mysqli ) {
 					if ( mysqli_ping( $dbh ) ) {
-						wp_cache_set( $dbh->thread_id, 'connected', 'non_persistent' );
+						wp_cache_add( $dbh->thread_id, 'connected', 'non_persistent' );
 						return true;
 					}
 				} else {
 					if ( mysql_ping( $dbh ) ) {
-						wp_cache_set( $dbh->thread_id, 'connected', 'non_persistent' );
+						wp_cache_add( $dbh->thread_id, 'connected', 'non_persistent' );
 						return true;
 					}
 				}


### PR DESCRIPTION
https://github.com/stuttter/ludicrousdb/issues/63
* add non-persistent group to store thread id connection during one page load
* removes heartbeat check