### PR TITLE
fix : PHP Warning:  Illegal offset type in class-ludicrousdb.php

### DIFF
--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -1478,8 +1478,7 @@ class LudicrousDB extends wpdb {
 			$result = mysql_query( $query, $dbh );
 		}
 
-
-		$this->dbhname_heartbeats[$dbh]['last_used'] = microtime( true );
+		$this->dbhname_heartbeats[$this->lookup_dbhs_name($dbh)]['last_used'] = microtime( true );
 
 		return $result;
 	}
@@ -2088,5 +2087,22 @@ class LudicrousDB extends wpdb {
 				$this->added_global_group = true;
 			}
 		}
+	}
+
+	/**
+	 * Find a dbhname value for a given $dbh object.
+	 *
+	 * @param object $dbh The dbh object for which to find the dbhname
+	 *
+	 * @return string The dbhname
+	 */
+	private function lookup_dbhs_name($dbh) {
+		foreach ($this->dbhs as $dbhname => $other_dbh) {
+			if ($dbh === $other_dbh) {
+				return $dbhname;
+			}
+		}
+
+		return false;
 	}
 }


### PR DESCRIPTION
error message : `PHP Warning:  Illegal offset type in .../ludicrousdb/ludicrousdb/includes/class-ludicrousdb.php`

The `$dbhname_heartbeats` array uses the name of the `$dbh` as key in other uses. In `_do_query` this value is not available and `$dbh` the object is used as key.

This is caused in part by using `$dbh` as a variable name for both a string and an object in the source code.

This fix is not ideal but it is small and seems to work well here.