### PR TITLE
When the host is a socket, always append the port

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,18 @@ This is the most basic way to add a server to LudicrousDB using only the require
 ```
 $wpdb->add_database( array(
 	'host'     => DB_HOST,     // If port is other than 3306, use host:port.
+	'is_socket'=> true,		   // If is true avoid to append the port to the host
 	'user'     => DB_USER,
 	'password' => DB_PASSWORD,
 	'name'     => DB_NAME,
 ) );
 ```
+
+**GCP connection string example**
+```
+:/cloudsql/project_name:region:instance_name
+```
+
 
 This adds the same server again, only this time it is configured as a slave. The last three parameters are set to the defaults but are shown for clarity.
 

--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -669,7 +669,8 @@ class LudicrousDB extends wpdb {
 					$min_group = $group;
 				}
 
-				$host_and_port = "{$host}:{$port}";
+				// If the variable `is_socket` is setted and is true avoid to add the port
+				$host_and_port = (isset($is_socket) && $is_socket) ? "{$host}": "{$host}:{$port}";
 
 				// Can be used by the lag callbacks
 				$this->lag_cache_key = $host_and_port;


### PR DESCRIPTION
I have fix it with a new variable and the checking it and then not adding the port when is a socket.
This works properly in GCP Appengine.