### PR TITLE
PHP 8 1 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-  "name": "stuttter/ludicrousdb",
+  "name": "humanmade/ludicrousdb",
   "description": "LudicrousDB is a database class that supports replication, failover, load balancing, & partitioning, based on Automattic's HyperDB drop-in.",
-  "homepage": "https://github.com/stuttter/ludicrousdb",
+  "homepage": "https://github.com/humanmade/ludicrousdb",
   "type": "wordpress-muplugin",
   "license"    : "GPL-2.0-or-later",
   "authors": [
@@ -15,8 +15,8 @@
     }
   ],
   "support"    : {
-    "issues": "https://github.com/stuttter/ludicrousdb/issues",
-    "source": "https://github.com/stuttter/ludicrousdb"
+    "issues": "https://github.com/humanmade/ludicrousdb/issues",
+    "source": "https://github.com/humanmade/ludicrousdb"
   },
   "require": {
     "php": ">=5.2",

--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -340,7 +340,7 @@ class LudicrousDB extends wpdb {
 		);
 
 		// Merge using defaults
-		$db      = array_merge( $db, $database_defaults );
+		$db      = wp_parse_args( $db, $database_defaults );
 
 		// Break these apart to make code easier to understand below
 		$dataset = $db['dataset'];

--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -1691,7 +1691,7 @@ class LudicrousDB extends wpdb {
 	 * @return false|string false on failure, version number on success
 	 */
 	public function db_version( $dbh_or_table = false ) {
-		return preg_replace( '/[^0-9.].*/', '', $this->db_server_info( $dbh ) );
+		return preg_replace( '/[^0-9.].*/', '', $this->db_server_info( $dbh_or_table ) );
 	}
 
 	/**

--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -1640,7 +1640,7 @@ class LudicrousDB extends wpdb {
 
 				if ( $this->dbh_type_check( $dbh ) ) {
 					if ( true === $this->use_mysqli ) {
-						$client_version = mysqli_get_client_info( $dbh );
+						$client_version = mysqli_get_client_info();
 					} else {
 						$client_version = mysql_get_client_info( $dbh );
 					}

--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -406,7 +406,7 @@ class LudicrousDB extends wpdb {
 		$q = ltrim( $q, "\r\n\t (" );
 
 		// Possible writes
-		if ( preg_match( '/(?:ALTER|CREATE|ANALYZE|CHECK|OPTIMIZE|REPAIR|CALL|DELETE|DROP|INSERT|LOAD|REPLACE|UPDATE|SET|RENAME)(?:\s|$)/i', $q ) ) {
+		if ( preg_match( '/(?:^|\s)(?:ALTER|CREATE|ANALYZE|CHECK|OPTIMIZE|REPAIR|CALL|DELETE|DROP|INSERT|LOAD|REPLACE|UPDATE|SET|RENAME\s+TABLE)(?:\s|$)/i', $q ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
Related Issue : https://github.com/humanmade/product-dev/issues/1198

```
PHP Deprecated:  mysqli_get_client_info(): Passing connection object as an argument is deprecated in /usr/src/app/vendor/humanmade/ludicrousdb/ludicrousdb/includes/class-ludicrousdb.php on line 1643
```

This issue resolves the deprecated notice with "To avoid the deprecation notice on all PHP versions, call the mysqli_get_client_info function without any parameters.".