### PR TITLE
Update class-ludicrousdb.php

### DIFF
--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -1644,7 +1644,7 @@ class LudicrousDB extends wpdb {
 
 				if ( $this->dbh_type_check( $dbh ) ) {
 					if ( true === $this->use_mysqli ) {
-						$client_version = mysqli_get_client_info( $dbh );
+						$client_version = mysqli_get_client_info();
 					} else {
 						$client_version = mysql_get_client_info( $dbh );
 					}


### PR DESCRIPTION
Solve 
PHP Deprecated:  mysqli_get_client_info(): Passing connection object as an argument is deprecated in PHP 8.1