### PR TITLE
Update composer development dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "composer/installers": "~1.0 || ~2.0"
   },
   "require-dev": {
-    "wp-coding-standards/wpcs": "^2.2",
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2",
+	"wp-coding-standards/wpcs": "^2.3",
+	"dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
     "sirbrillig/phpcs-variable-analysis": "^2.8"
   },
@@ -35,5 +35,11 @@
     "lint": [
       "vendor/bin/phpcs . -v"
     ]
+  },
+  "config": {
+    "allow-plugins": {
+      "composer/installers": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }


### PR DESCRIPTION
They can now be installed with composer v2.
GitHub Actions can now actually run.