### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "stuttter/ludicrousdb",
+  "name": "slackarse/ludicrousdb",
   "description": "LudicrousDB is a database class that supports replication, failover, load balancing, & partitioning, based on Automattic's HyperDB drop-in.",
   "homepage": "https://github.com/stuttter/ludicrousdb",
   "type": "wordpress-plugin",

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name": "slackarse/ludicrousdb",
+  "name": "stuttter/ludicrousdb",
   "description": "LudicrousDB is a database class that supports replication, failover, load balancing, & partitioning, based on Automattic's HyperDB drop-in.",
-  "homepage": "https://github.com/slackarse/ludicrousdb",
-  "type": "wordpress-plugin",
+  "homepage": "https://github.com/stuttter/ludicrousdb",
+  "type": "wordpress-muplugin",
   "license"    : "GPL-2.0-or-later",
   "authors": [
     {
@@ -15,8 +15,8 @@
     }
   ],
   "support"    : {
-    "issues": "https://github.com/slackarse/ludicrousdb/issues",
-    "source": "https://github.com/slackarse/ludicrousdb"
+    "issues": "https://github.com/stuttter/ludicrousdb/issues",
+    "source": "https://github.com/stuttter/ludicrousdb"
   },
   "require": {
     "php": ">=5.2",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "stuttter/ludicrousdb",
   "description": "LudicrousDB is a database class that supports replication, failover, load balancing, & partitioning, based on Automattic's HyperDB drop-in.",
   "homepage": "https://github.com/stuttter/ludicrousdb",
-  "type": "wordpress-muplugin",
+  "type": "wordpress-plugin",
   "license"    : "GPL-2.0-or-later",
   "authors": [
     {

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name": "stuttter/ludicrousdb",
+  "name": "slackarse/ludicrousdb",
   "description": "LudicrousDB is a database class that supports replication, failover, load balancing, & partitioning, based on Automattic's HyperDB drop-in.",
-  "homepage": "https://github.com/stuttter/ludicrousdb",
-  "type": "wordpress-muplugin",
+  "homepage": "https://github.com/slackarse/ludicrousdb",
+  "type": "wordpress-plugin",
   "license"    : "GPL-2.0-or-later",
   "authors": [
     {
@@ -15,8 +15,8 @@
     }
   ],
   "support"    : {
-    "issues": "https://github.com/stuttter/ludicrousdb/issues",
-    "source": "https://github.com/stuttter/ludicrousdb"
+    "issues": "https://github.com/slackarse/ludicrousdb/issues",
+    "source": "https://github.com/slackarse/ludicrousdb"
   },
   "require": {
     "php": ">=5.2",

--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -1106,7 +1106,7 @@ class LudicrousDB extends wpdb {
 	public function _real_escape( $string ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
 
 		// Slash the query part
-		$escaped = addslashes( $string );
+		$escaped = addslashes( $string ?? '' );
 
 		// Maybe use WordPress core placeholder method
 		if ( method_exists( $this, 'add_placeholder_escape' ) ) {

--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -409,7 +409,7 @@ class LudicrousDB extends wpdb {
 		$q = ltrim( $q, "\r\n\t (" );
 
 		// Possible writes
-		if ( preg_match( '/(?:^|\s)(?:ALTER|CREATE|ANALYZE|CHECK|OPTIMIZE|REPAIR|CALL|DELETE|DROP|INSERT|LOAD|REPLACE|UPDATE|SET|RENAME\s+TABLE)(?:\s|$)/i', $q ) ) {
+		if ( preg_match( '/(?:^|\s)(?:ALTER|CREATE|ANALYZE|CHECK|OPTIMIZE|REPAIR|CALL|DELETE|DROP|INSERT|LOAD|REPLACE|UPDATE|SET|RENAME\s+TABLE|[a-z]+_LOCKS?\()(?:\s|$)/i', $q ) ) {
 			return true;
 		}
 

--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -471,6 +471,10 @@ class LudicrousDB extends wpdb {
 			return false;
 		}
 
+		if ( $this->use_mysqli ) {
+			mysqli_report( MYSQLI_REPORT_OFF );
+		}
+
 		// can be empty/false if the query is e.g. "COMMIT"
 		$this->table = $this->get_table_from_query( $query );
 		if ( empty( $this->table ) ) {
@@ -914,8 +918,8 @@ class LudicrousDB extends wpdb {
 
 			// mysqli_real_connect doesn't support the host param including a port or socket
 			// like mysql_connect does. This duplicates how mysql_connect detects a port and/or socket file.
-			$port           = null;
-			$socket         = null;
+			$port           = 0;
+			$socket         = '';
 			$port_or_socket = strstr( $host, ':' );
 
 			if ( ! empty( $port_or_socket ) ) {
@@ -943,7 +947,7 @@ class LudicrousDB extends wpdb {
 				$pre_host = 'p:';
 			}
 
-			mysqli_real_connect( $this->dbhs[ $dbhname ], $pre_host . $host, $user, $password, null, $port, $socket, $client_flags );
+			mysqli_real_connect( $this->dbhs[ $dbhname ], $pre_host . $host, $user, $password, '', $port, $socket, $client_flags );
 
 			if ( $this->dbhs[ $dbhname ]->connect_errno ) {
 				$this->dbhs[ $dbhname ] = false;


### PR DESCRIPTION
Minor updates for PHP 8.1 compatibility, fixing deprecation notices, and suppressing error reports to prevent fatal errors (particularly in WordPress)

Add lock functions to possible writes to fix read only instance issues with WordFence - merged from humanmade fork
https://github.com/humanmade/ludicrousdb/commit/b0ea68d29462f4de7e858583d48c9f5d6dbc7826