### PR TITLE
prevent "SELECT FOUND_ROWS" possibly returning an unrelated result

### DIFF
--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -1810,6 +1810,8 @@ class LudicrousDB extends wpdb {
 					$elapsed                     += $this->timer_stop();
 					++$this->num_queries;
 					$query .= '; SELECT FOUND_ROWS()';
+				} else {
+					$this->last_found_rows_result = null;
 				}
 			} else {
 				$this->last_found_rows_result = null;


### PR DESCRIPTION
if multiple queries are run for rows, the 2nd query would possibly return rows found of first if the first query rows are not retrieved