### PR TITLE
Fix: Call init_charset() in constructor to initialize charset/collate

### DIFF
--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -384,6 +384,9 @@ class LudicrousDB extends wpdb {
 
 		// Prepare class vars
 		$this->prepare_class_vars( $dbuser, $dbpassword, $dbname, $dbhost );
+
+		// Initialize charset and collate
+		$this->init_charset();
 	}
 
 	/**
@@ -1570,9 +1573,9 @@ class LudicrousDB extends wpdb {
 			$collate = $this->collate;
 		}
 
-		// Exit if charset or collation are empty
-		if ( empty( $charset ) || empty( $collate ) ) {
-			wp_die( "{$charset}  {$collate}" );
+		// Exit if charset is empty
+		if ( empty( $charset ) ) {
+			return;
 		}
 
 		// Exit if charset is not allowed


### PR DESCRIPTION
## Summary

- Call init_charset() in __construct() after prepare_class_vars()
- In set_charset(), only check empty($charset) and return instead of wp_die()
- Remove empty($collate) from the guard clause since DB_COLLATE is empty string by default in WordPress

## Context

init_charset() is overridden (L523) but never called anywhere, leaving $this->charset and $this->collate as empty strings. When db_connect() calls set_charset(), the empty values hit the guard clause and trigger wp_die('') with no error message.

Most users don't hit this because the recommended db-config.php sets $wpdb->charset / $wpdb->collate directly, but configurations that rely on DB_CHARSET / DB_COLLATE constants (the standard WordPress mechanism) fail silently.

## Why __construct() and not db_connect()

Placing init_charset() in __construct() (after prepare_class_vars()) rather than in db_connect() ensures:

1. **No redundant calls** — db_connect() is called per connection/query; init_charset() only needs to run once
2. **User overrides are preserved** — db-config.php is loaded after __construct(), so $wpdb->charset / $wpdb->collate set in db-config.php take precedence
3. **Fallback path coverage** — when ludicrous_servers is empty, parent::db_connect() is called which expects charset to already be initialized

This matches the initialization order in wpdb, where init_charset() is called during construction before any connection is made.

## Reference: wpdb::db_connect()

```php
// wp-includes/class-wpdb.php - wpdb::db_connect()
if ( ! $this->has_connected ) {
    $this->init_charset();
}
$this->has_connected = true;
$this->set_charset( $this->dbh );
```

Fixes #206