### PR TITLE
Mark single_db_connect password sensitive with PHP 7-safe formatting

### DIFF
--- a/ludicrousdb/includes/class-ludicrousdb.php
+++ b/ludicrousdb/includes/class-ludicrousdb.php
@@ -1321,7 +1321,14 @@ class LudicrousDB extends wpdb {
 	 *
 	 * @return bool|mysqli|resource
 	 */
-	protected function single_db_connect( $dbhname, $host, $user, $password ) {
+
+    protected function single_db_connect(
+        $dbhname,
+        $host,
+        $user,
+        #[\SensitiveParameter]
+        $password
+    ) {
 		$tcp_cache_key  = $host;
 		$this->is_mysql = true;
 


### PR DESCRIPTION
Marks $password with #[\SensitiveParameter] so PHP 8.2+ redacts it in stack traces/backtraces.
Formats across multiple lines so on PHP 7 (where # starts a comment) only the attribute line is ignored, preserving valid syntax.